### PR TITLE
HOTT-3198: Adds simple object explorer for report navigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,3 +29,7 @@ workflows:
     jobs:
       - deploy:
           context: trade-tariff-bot-aws-production
+          filters:
+            branches:
+              ignore:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+orbs:
+  aws-cli: circleci/aws-cli@2.0.3
+
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:2023.05
+    steps:
+      - aws-cli/install
+      - checkout
+      - run:
+          name: "Deploy"
+          command: |
+            aws s3 cp index.html s3://trade-tariff-reporting/
+
+            DISTRIBUTION_ID=$(aws cloudfront list-distributions | \
+              jq -r '.DistributionList.Items[] | select(.Aliases.Items[]? | contains("reporting.trade-tariff.service.gov.uk")) | .Id')
+
+            aws cloudfront create-invalidation \
+              --distribution-id $DISTRIBUTION_ID \
+              --paths "/index.html"
+
+workflows:
+  version: 2
+
+  deploy:
+    jobs:
+      - deploy:
+          context: trade-tariff-bot-aws-production

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # trade-tariff-reporting
-Simple reporting folder explorer for public navigation of generated reports
+
+Simple reporting folder explorer for public navigation of generated reports.
+
+This deploys a single index.html file which can be used to navigate any reports that are pushed to this repository

--- a/index.html
+++ b/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Reports</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <style>
+    .indent {
+      margin-left: 20px;
+    }
+
+    .folder,
+    .file {
+      cursor: pointer;
+      padding: 5px;
+      border: 1px solid #ddd;
+      border-radius: 5px;
+      background-color: #f9f9f9;
+      margin-bottom: 5px;
+      text-decoration: none;
+      color: black;
+      display: inline-block;
+      width: calc(100% - 20px);
+    }
+
+    .folder:hover,
+    .file:hover {
+      background-color: #eaeaea;
+    }
+
+    .folder:before {
+      content: "\1F4C1";
+      /* Unicode character for 'Folder' emoji */
+      margin-right: 5px;
+    }
+
+    .file:before {
+      content: "\1F4C4";
+      /* Unicode character for 'Page Facing Up' emoji */
+      margin-right: 5px;
+    }
+
+    .csv:before,
+    .xls:before,
+    .xlsx:before {
+      content: "\1F4C3";
+      /* Unicode character for 'Spreadsheet' emoji */
+      margin-right: 5px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Online Trade Tariff Reports Directory</h1>
+  <div id="content"></div>
+  <script>
+    var bucketUrl = 'https://reporting.trade-tariff.service.gov.uk';
+    var openLevels = 2; // Change this to configure the depth of the open levels
+    var folderState = JSON.parse(localStorage.getItem('folderState')) || {};
+
+    $.get(bucketUrl + '/')
+      .done(function (data) {
+        var structure = {};
+
+        $(data).find('Key').each(function () {
+          var key = $(this).text();
+
+          // Exclude objects with a key prefix of 'changes' or a suffix of '.html'
+          if (key.startsWith('changes') || key.endsWith('.html')) {
+            return true; // Skip this iteration and move on to the next one
+          }
+
+          var parts = key.split('/');
+          var subtree = structure;
+
+          for (var i = 0; i < parts.length; i++) {
+            if (!subtree[parts[i]]) {
+              subtree[parts[i]] = {};
+            }
+            subtree = subtree[parts[i]];
+          }
+        });
+
+        function buildHtml(tree, indentLevel, path = '') {
+          var html = '';
+          var sortedKeys = Object.keys(tree).sort();
+
+          for (var i = 0; i < sortedKeys.length; i++) {
+            var key = sortedKeys[i];
+            var newPath = path + '/' + key;
+            var url = bucketUrl + newPath;
+            var extension = key.split('.').pop();
+
+            html += '<div class="indent" style="margin-left: ' + (indentLevel * 20) + 'px;">';
+            if (Object.keys(tree[key]).length > 0) {
+              // It's a folder
+              html += '<div class="folder" onclick="toggleFolder(\'' + newPath + '\', this)">' + key + '</div>';
+              var isOpen = folderState.hasOwnProperty(newPath) ? folderState[newPath] : indentLevel < openLevels;
+              html += '<div id="' + newPath + '" style="' + (isOpen ? 'display: block;' : 'display: none;') + '">' + buildHtml(tree[key], indentLevel + 1, newPath) + '</div>';
+            } else {
+              // It's a file
+              if (extension === 'csv' || extension === 'xls' || extension === 'xlsx') {
+                html += '<a class="file csv" href="' + url + '" target="_blank">' + key + '</a>';
+              } else {
+                html += '<a class="file" href="' + url + '" target="_blank">' + key + '</a>';
+              }
+            }
+            html += '</div>';
+          }
+
+          return html;
+        }
+
+        $('#content').html(buildHtml(structure, 0));
+
+        window.toggleFolder = function (path, el) {
+          $(el).next().toggle();
+          folderState[path] = !folderState[path];
+          localStorage.setItem('folderState', JSON.stringify(folderState));
+        };
+      })
+      .fail(function (error) {
+        console.log('There was an error: ', error);
+      });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Jira Link

https://transformuk.atlassian.net/browse/HOTT-3198

![image](https://github.com/trade-tariff/trade-tariff-reporting/assets/8156884/5d7c235b-1bc5-4a59-858b-5f5041368a58)

### What?

I have added/removed/altered:

- [x] Adds a object explorer for navigating the reports repo
- [x] Adds deployment process for the explorer which includes a cloudfront invalidation

### Why?

I am doing this because:

- This helps users navigate reports more easily and none of the other solutions I could find work in quite the way I wanted (they don't support navigation of a tree structure using folders)
- I've not added search/grid view for now since this felt like overkill for our use case
