### PR TITLE
HOTT-3198: Filter deploys to only main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,5 @@ workflows:
           context: trade-tariff-bot-aws-production
           filters:
             branches:
-              ignore:
+              only:
                 - main


### PR DESCRIPTION
This was a copy pasta issue in a previous PR