### PR TITLE
BAU: Add licence, GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+### Jira link
+
+HOTT-<TODO>
+
+### What?
+
+I have added/removed/altered:
+
+- [ ] Added foo in bar
+- [ ] Removed baz
+
+### Why?
+
+I am doing this because:
+
+-
+-
+-
+
+### Have you? (optional)
+
+- [ ] Considered downstream applications that are effected by this change
+- [ ] Made the change on development and staging environments first
+- [ ] Configured the applications to take advantage of your change
+- [ ] Considered risks of data loss, security, etc

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (C) 2023 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,7 @@
 
 Simple reporting folder explorer for public navigation of generated reports.
 
-This deploys a single index.html file which can be used to navigate any reports that are pushed to this repository
+This deploys a single index.html file which can be used to navigate any reports
+that are pushed to this repository.
+
+Report files can be downloaded from <https://reporting.trade-tariff.service.gov.uk>.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Simple reporting folder explorer for public navigation of generated reports.
 This deploys a single index.html file which can be used to navigate any reports
 that are pushed to this repository.
 
-Report files can be downloaded from <https://reporting.trade-tariff.service.gov.uk>.
+Report files can be downloaded from <https://reporting.trade-tariff.service.gov.uk/index.html>.


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added the licence that covers this work.
- Added the standard Trade Tariff GitHub pull request template.
- Added a link to the reports site.

### Why?

I am doing this because:

- This repository is public and we [code in the open](https://www.gov.uk/service-manual/service-standard/point-12-make-new-source-code-open)
- We have the PR template in most other repositories and it's a nice to have.
- A link makes it easier for people to go directly to the reports site from the repo.