### PR TITLE
OTT-224 Get Data by Month to Avoid AWS Data Truncation

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,36 @@
     const folderState = JSON.parse(localStorage.getItem('folderState')) || {};
     const structure = {};
     const maxKeys = 5000;
-    const bucketPrefixes = ['uk', 'xi'];
+    // AWS Truncates data so to avoid truncated data problems each month's data is loaded separately.
+    // See Jira OTT-224 https://transformuk.atlassian.net/browse/OTT-224
+    const startDate = new Date(2023, 9);  // October 2023 as this is when AWS migration happened.
+    const bucketPrefixes = generateMonthlyPrefixes(startDate);
+    
+    // Function to get an array of months from a start date to the current date
+    function generateMonthlyPrefixes(startDate) {
+      const prefixes = [];  
+      const currentDate = new Date(); 
+      let currentYear = startDate.getFullYear();
+      let currentMonth = startDate.getMonth() + 1;
+
+      while (currentYear < currentDate.getFullYear() || 
+            (currentYear === currentDate.getFullYear() && currentMonth <= currentDate.getMonth() + 1)) {
+        const formattedMonth = currentMonth.toString().padStart(2, '0');  // Ensure 2-digit month format
+
+        const ukPrefix = `uk/reporting/${currentYear}/${formattedMonth}`;
+        const xiPrefix = `xi/reporting/${currentYear}/${formattedMonth}`;
+
+        prefixes.push(ukPrefix);  
+        prefixes.push(xiPrefix);
+        
+        currentMonth++;
+        if (currentMonth > 12) {
+          currentMonth = 1;  // Reset to January
+          currentYear++;  // Increment the year
+        }
+      }
+      return prefixes;
+    }
 
     function formatFileSize(bytes) {
       const sizes = [

--- a/index.html
+++ b/index.html
@@ -60,36 +60,36 @@
     const folderState = JSON.parse(localStorage.getItem('folderState')) || {};
     const structure = {};
     const maxKeys = 5000;
-    // AWS Truncates data so to avoid truncated data problems each month's data is loaded separately.
-    // See Jira OTT-224 https://transformuk.atlassian.net/browse/OTT-224
-    const startDate = new Date(2023, 9);  // October 2023 as this is when AWS migration happened.
-    const bucketPrefixes = generateMonthlyPrefixes(startDate);
+   
+    // Get the past three months' prefixes
+    const bucketPrefixes = generateLastThreeMonthsPrefixes();
     
-    // Function to get an array of months from a start date to the current date
-    function generateMonthlyPrefixes(startDate) {
-      const prefixes = [];  
-      const currentDate = new Date(); 
-      let currentYear = startDate.getFullYear();
-      let currentMonth = startDate.getMonth() + 1;
+    function generateLastThreeMonthsPrefixes() {
+    const prefixes = [];
+    const currentDate = new Date();
+    let currentYear = currentDate.getFullYear();
+    let currentMonth = currentDate.getMonth() + 1;
 
-      while (currentYear < currentDate.getFullYear() || 
-            (currentYear === currentDate.getFullYear() && currentMonth <= currentDate.getMonth() + 1)) {
-        const formattedMonth = currentMonth.toString().padStart(2, '0');  // Ensure 2-digit month format
+    // Calculate the starting point for the last three months
+    const startMonth = currentMonth - 2;
+    const startYear = startMonth <= 0 ? currentYear - 1 : currentYear;
+    const startAdjustedMonth = startMonth <= 0 ? 12 + startMonth : startMonth;
 
-        const ukPrefix = `uk/reporting/${currentYear}/${formattedMonth}`;
-        const xiPrefix = `xi/reporting/${currentYear}/${formattedMonth}`;
+    // Generate the range of prefixes for the past three months
+    for (let i = 0; i < 3; i++) {
+      const month = (startAdjustedMonth + i) % 12 || 12;
+      const year = (startAdjustedMonth + i) > 12 ? startYear + 1 : startYear;
+      
+      const formattedMonth = month.toString().padStart(2, '0');  // Ensure 2-digit month format
+      const ukPrefix = `uk/reporting/${year}/${formattedMonth}`;
+      const xiPrefix = `xi/reporting/${year}/${formattedMonth}`;
 
-        prefixes.push(ukPrefix);  
-        prefixes.push(xiPrefix);
-        
-        currentMonth++;
-        if (currentMonth > 12) {
-          currentMonth = 1;  // Reset to January
-          currentYear++;  // Increment the year
-        }
-      }
-      return prefixes;
+      prefixes.push(ukPrefix);  
+      prefixes.push(xiPrefix);
     }
+
+    return prefixes;
+  }
 
     function formatFileSize(bytes) {
       const sizes = [


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-224

### What?

I have altered:

- [x] AWS S3 AJAX requests to fetch past 3 months of data

### Why?

I am doing this because:

- Production and staging will hold only 3 months of reports, Dev will hold 2 weeks.

### Have you? (optional)

- [x] Considered downstream applications that are effected by this change
- [x] Made the change on development and staging environments first

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-reporting/assets/127106895/b2402edc-dd9c-4aa2-afb2-6c22b7cb20a3)

AFTER
<img width="551" alt="image" src="https://github.com/trade-tariff/trade-tariff-reporting/assets/127106895/312298c3-054d-4303-a2fe-df76852f3dcf">
