### PR TITLE
HMRC-1458: Limit prod deploy trigger to main branch only

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -1,10 +1,8 @@
 name: Buld and Deploy to Development
 
 on:
-  push:
-    branches-ignore:
-      - main
   workflow_dispatch:
+  pull_request:
 
 permissions:
     id-token: write

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,11 +1,13 @@
 name: Buld and Deploy to Production
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Buld and Deploy to Staging"]
     types:
       - completed
-  workflow_dispatch:
+    branches:
+      - main
 
 permissions:
     id-token: write
@@ -19,7 +21,7 @@ env:
 
 jobs:
     build-deploy:
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,10 +1,10 @@
 name: Buld and Deploy to Staging
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions:
     id-token: write


### PR DESCRIPTION
### Jira link

[HMRC-1458](https://transformuk.atlassian.net/browse/HMRC-1458)

### What?

I have added/removed/altered:

- [x] added a condition to the production workflow so it only runs if the staging workflow was triggered from the main branch

### Why?

I am doing this because:

- Ensure production is only deployed after a successful automated staging deployment from the main branch
