### PR TITLE
HMRC-2267: Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Pull request

### What?
Added Dependabot config for github-actions

### Why?
To enable automated dependency updates across GitHub Actions.

### Ticket
[HMRC-2267](https://transformuk.atlassian.net/browse/HMRC-2267)

### Risk
**Risk level: 🟢

Reason for rating:**